### PR TITLE
Fix duplicate BlockNote editor save instances causing JSON decode erros 

### DIFF
--- a/backend/src/task_operations.py
+++ b/backend/src/task_operations.py
@@ -18,6 +18,11 @@ def create_task(handle, task_data):
     new_task = Task()
     new_task.new(handle, task_data["project_id"], task_data)
     set_task_active(new_task.t_id, new_task)
+    with open(f"{BASE_DIR}/task_content/{new_task.t_id}.json", "w", encoding="utf-8") as fp:
+        json.dump([{
+        "time": time.time(),
+        "content": []
+    }], fp)
     return {}
 
 
@@ -179,97 +184,6 @@ def get_user_ids(users_handles):
 def task_comment(handle, task_id, text, replied_comment_id):
     Comment(task_id).new(handle, text, replied_comment_id)
     # TODO - notifications and achievements
-        # project_id = cur.execute(
-        #     """
-        #         SELECT tasks.project
-        #         FROM users
-        #         JOIN tasks
-        #         ON users.id = tasks.creator
-        #         WHERE tasks.id=?
-        #     """,
-        #     (task_id,),
-        # ).fetchone()[0]
-
-        #  Achievements: Write comments
-        # update_achievement("First!", poster_id)
-        # update_achievement("Thread Weaver", poster_id)
-
-        # if replied_comment_id == -1:
-        #     # task creator gets a notification from a comment on the task
-        #     # people assigned to the task will also get a comment
-        #     creator_email = cur.execute(
-        #         """
-        #             SELECT email
-        #             FROM users
-        #             JOIN tasks
-        #             ON users.id = tasks.creator
-        #             WHERE tasks.id=?
-        #         """,
-        #         (task_id,),
-        #     ).fetchone()[0]
-
-        #     assignees_data = cur.execute(
-        #         """
-        #         SELECT users.email
-        #         FROM tasks
-        #         JOIN assigned
-        #         ON tasks.id = assigned.task                
-        #         JOIN users
-        #         ON users.id = assigned.user
-        #         WHERE tasks.id=?
-        #     """,
-        #         (task_id,),
-        #     ).fetchall()
-
-        #     # Send notifications to assignees of the task being commented on
-        #     # unless they are the task creator, or were the commentor
-        #     for assignees_email in assignees_data:
-        #         if assignees_email[0] != creator_email and assignees_email[0] != email:
-        #             conn.commit()
-        #             add_notification(
-        #                 assignees_email[0],
-        #                 poster_handle,
-        #                 "comment",
-        #                 "comment",
-        #                 f"has commented on a task you were assigned",
-        #                 project_id,
-        #             )
-
-        #     if email != creator_email:
-        #         # no notification when commenting to your own task
-        #         conn.commit()
-        #         add_notification(
-        #             creator_email,
-        #             poster_handle,
-        #             "comment",
-        #             "comment",
-        #             f"has commented on your task",
-        #             project_id,
-        #         )
-        # else:
-        #     # user gets a notification if someone replies to their comment
-        #     poster_email = cur.execute(
-        #         """
-        #             SELECT email 
-        #             FROM users
-        #             JOIN comments
-        #             ON users.id = comments.poster
-        #             WHERE comments.id=?
-        #         """,
-        #         (replied_comment_id,),
-        #     ).fetchone()[0]
-
-        #     if email != poster_email:
-        #         # no notification when replying to your own comment
-        #         conn.commit()
-        #         add_notification(
-        #             poster_email,
-        #             poster_handle,
-        #             "comment",
-        #             "reply",
-        #             f"has replied to your comment",
-        #             project_id,
-        #         )
 
 
 def task_get_comment(task_id):
@@ -345,7 +259,7 @@ def get_task_edit(task_id):
         with open(f"{BASE_DIR}/task_content/{task_id}.json", "r", encoding="utf-8") as fp:
             edit_history = sorted(json.load(fp), key=lambda edit: edit["time"])
             return edit_history[-1]["content"]
-    except FileNotFoundError:
+    except (FileNotFoundError, KeyError) as err:
         return []
     
 def get_task_content(project_id):
@@ -377,8 +291,8 @@ def update_task_edit(task_id, task_content: list):
     try:
         with open(f"{BASE_DIR}/task_content/{task_id}.json", "r", encoding="utf-8") as fp:
             edit_history = json.load(fp)
-            get_edit_difference(edit_history[-1]["content"], task_content)
-    except FileNotFoundError:
+            # get_edit_difference(edit_history[-1]["content"], task_content)
+    except (FileNotFoundError, AttributeError) as error:
         print("Task edit history not found")
 
     edit_history.append({
@@ -387,6 +301,10 @@ def update_task_edit(task_id, task_content: list):
     })
     with open(f"{BASE_DIR}/task_content/{task_id}.json", "w", encoding="utf-8") as fp:
         json.dump(edit_history, fp)
+        # json.dump([{
+        #     "time": time.time(),
+        #     "content": task_content
+        # }], fp)
 
 
 def get_task_edit_history(task_id):

--- a/frontend/src/components/Editor.jsx
+++ b/frontend/src/components/Editor.jsx
@@ -82,7 +82,17 @@ const Editor = ({ initialBlocks, taskId, canEdit = true }) => {
   let timeoutId;
   const editor = useBlockNote({
     editable: canEdit,
-    initialContent: initialBlocks.length > 0 ? initialBlocks : placeholder,
+    initialContent: initialBlocks.length > 0 ? initialBlocks : undefined,
+    onEditorContentChange: (editor) => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(async () => {
+        console.log('saving...');
+        const blocks = editor.topLevelBlocks;
+        await fetchAPIRequest(`/task/edit/content?taskId=${taskId}`, 'PUT', {
+          blocks,
+        });
+      }, 1000);
+    },
     blockSchema: customSchema,
     slashMenuItems: [...getDefaultReactSlashMenuItems(customSchema)],
     domAttributes: {
@@ -91,19 +101,6 @@ const Editor = ({ initialBlocks, taskId, canEdit = true }) => {
         class: 'block-container',
       },
     },
-  });
-  editor.onEditorContentChange((e) => {
-    if (initRender) return;
-    clearTimeout(timeoutId);
-    timeoutId = setTimeout(async () => {
-      console.log('saving...');
-      const blocks = editor.topLevelBlocks;
-      await fetchAPIRequest(`/task/edit/content?taskId=${taskId}`, 'PUT', {
-        blocks,
-      });
-    }, 500);
-
-    // console.table(blocks);
   });
 
   // Renders the editor instance using a React component.


### PR DESCRIPTION
This PR fixes a bug caused by an improper use of the BlockNote editor's onEditorChange function. With a few changes made in the editor, multiple save requests would be called, likely overloading the backend and causing extra braces and brackets to be added in each task's JSON file.

To fix this, I
- Removed the direct editor.onEditorChange function
- Used the onEditorChange prop within the useBlockNote hook with the above function's logic